### PR TITLE
Minor: URL for description from blog post was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An implementation of Privacy Pass in Rust, compatible with [https://github.com/privacypass](https://github.com/privacypass).
 
-Described in the post [https://kobigurk.com/2019/01/05/exploring-privacypass.html](https://kobigurk.com/2019/01/05/exploring-privacypass.html).
+Described in the post [https://kobi.one/2019/01/05/exploring-privacypass.html](https://kobi.one/2019/01/05/exploring-privacypass.html).
 
 The *example-data* folder contains example configuration files for both the client and the server, a secret key for the server and a public commitment for the key to be used by the client.
 


### PR DESCRIPTION
Minor issue in README, the URL for the blog post description seems to have changed to [https://kobi.one/2019/01/05/exploring-privacypass.html](https://kobi.one/2019/01/05/exploring-privacypass.html).

